### PR TITLE
simplify run_export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
 services:
   - docker
+language: ruby
+rvm:
+  - 2.4.4
 
 install:
     docker build . -t lib-mapknitter-exporter:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: required
 services:
   - docker
-language: ruby
-rvm:
-  - 2.4.4
+#language: ruby
+#rvm:
+#  - 2.4.4
 
 install:
     docker build . -t lib-mapknitter-exporter:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: required
 services:
   - docker
-#language: ruby
-#rvm:
-#  - 2.4.4
 
 install:
     docker build . -t lib-mapknitter-exporter:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://packages.laboratoriopublico.org/publiclab/ stretch main" > 
 # Obtain key
 RUN mkdir ~/.gnupg
 RUN echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-RUN apt-key adv --keyserver fks.pgpkeys.eu --recv-keys BF26EE05EA6A68F0
+RUN apt-key adv --keyserver ipv4.pool.sks-keyservers.net --recv-keys BF26EE05EA6A68F0
 
 # Install dependencies
 RUN apt-get update -qq && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ require 'mapknitter-exporter'
 
 MapKnitterExporter.generate_perspectival_distort(
   scale,
-  'map',
-  nodes_array,
   1, # a unique id
+  nodes_array,
   'test/fixtures/demo.png',
   image,
   height,

--- a/README.md
+++ b/README.md
@@ -7,12 +7,17 @@ Then, use it with:
 ```ruby
 require 'mapknitter-exporter'
 
-# not sure this will work:
+# this should work:
 
 MapKnitterExporter.generate_perspectival_distort(
   scale,
   1, # a unique id
-  nodes_array,
+  [
+    { lat: 41.8403113680142, lon: -71.3983854668186 },
+    { lat: 41.8397358653566, lon: -71.3916477577732 },
+    { lat: 41.8351476451765, lon: -71.392699183707  },
+    { lat: 41.8377535388085, lon: -71.3981708900974 }
+  ],
   'test/fixtures/demo.png',
   image,
   height,
@@ -22,6 +27,6 @@ MapKnitterExporter.generate_perspectival_distort(
 
 ## Tests
 
-Tests are not passing completely but they are running; use `ruby test/exporter_test.rb` to run them.
+To run tests, use `ruby test/exporter_test.rb`.
 
 Tests require `minitest` which you can install with `bundle install`.

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -33,7 +33,7 @@ class MapKnitterExporter
     # this is just so we can use the files locally outside of s3
     working_directory = get_working_directory(id)
     Dir.mkdir(working_directory) unless (File.exists?(working_directory) && File.directory?(working_directory))
-    local_location = working_directory+id.to_s+'-'+image_file_name.to_s
+    local_location = "#{working_directory}#{id}-#{image_file_name}"
 
     directory = warps_directory(id)
     Dir.mkdir(directory) unless (File.exists?(directory) && File.directory?(directory))
@@ -255,7 +255,7 @@ class MapKnitterExporter
   # generate a tiff from all warpable images in this set
   def self.generate_composite_tiff(coords, origin, placed_warpables, id, ordered)
     directory = "public/warps/#{id}/"
-    composite_location = directory+id+'-geo.tif'
+    composite_location = directory + id.to_s + '-geo.tif'
     geotiffs = ''
     minlat = nil
     minlon = nil
@@ -278,10 +278,10 @@ class MapKnitterExporter
       wid = warpable[:id].to_s
       geotiffs += ' '+directory+wid+'-geo.tif'
       if first
-        gdalwarp = "gdalwarp -s_srs EPSG:3857 -te "+minlon.to_s+" "+minlat.to_s+" "+maxlon.to_s+" "+maxlat.to_s+" "+directory+wid+'-geo.tif '+directory+id+'-geo.tif'
+        gdalwarp = "gdalwarp -s_srs EPSG:3857 -te #{minlon} #{minlat} #{maxlon} #{maxlat} #{directory}#{wid}-geo.tif #{directory}#{id}-geo.tif"
         first = false
       else
-        gdalwarp = "gdalwarp "+directory+wid+'-geo.tif '+directory+id+'-geo.tif'
+        gdalwarp = "gdalwarp #{directory}#{wid}-geo.tif #{directory}#{id}-geo.tif"
       end
       puts gdalwarp
       system(self.ulimit+gdalwarp)

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -305,7 +305,7 @@ class MapKnitterExporter
 
   # generates a tileset at public/tms/<id>/
   def self.generate_jpg(id, root)
-    imageMagick = "convert -background white -flatten #{root}/public/warps/#{id}/#{id}-geo.tif #{root}/public/warps/#{id}/#{id}.jpg"
+    imageMagick = "convert -background white -flatten public/warps/#{id}/#{id}-geo.tif #{root}/public/warps/#{id}/#{id}.jpg"
     system(self.ulimit+imageMagick)
   end
 

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -82,10 +82,6 @@ class MapKnitterExporter
       }
     else
       require "fileutils"
-      puts '>>>>>>>>>>>>>>oldfashioned'
-      puts 'img_url, local_location'
-      puts img_url
-      puts local_location
       FileUtils.cp(img_url, local_location)
     end
 

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -254,7 +254,7 @@ class MapKnitterExporter
 
   # generate a tiff from all warpable images in this set
   def self.generate_composite_tiff(coords, origin, placed_warpables, id, ordered)
-    directory = "public/warps/"+id+"/"
+    directory = "public/warps/#{id}/"
     composite_location = directory+id+'-geo.tif'
     geotiffs = ''
     minlat = nil
@@ -294,22 +294,22 @@ class MapKnitterExporter
   def self.generate_tiles(key, id, root)
     key = "AIzaSyAOLUQngEmJv0_zcG1xkGq-CXIPpLQY8iQ" if key == "" # ugh, let's clean this up!
     key = key || "AIzaSyAOLUQngEmJv0_zcG1xkGq-CXIPpLQY8iQ"
-    gdal2tiles = 'gdal2tiles.py -k --s_srs EPSG:3857 -t "'+id+'" -g "'+key+'" '+'public/warps/'+id+'/'+id+'-geo.tif '+'public/tms/'+id+"/"
+    gdal2tiles = "gdal2tiles.py -k --s_srs EPSG:3857 -t #{id} -g #{key} public/warps/#{id}/#{id}-geo.tif public/tms/#{id}/"
     puts gdal2tiles
     system(self.ulimit+gdal2tiles)
   end
 
   # zips up tiles at public/tms/<id>.zip;
   def self.zip_tiles(id)
-    rmzip = 'cd public/tms/ && rm '+id+'.zip && cd ../../'
+    rmzip = "cd public/tms/ && rm #{id}.zip && cd ../../"
     system(rmzip)
-    zip = 'cd public/tms/ && ' + self.ulimit + 'zip -rq '+id+'.zip '+id+'/ && cd ../../'
+    zip = "cd public/tms/ && #{self.ulimit} zip -rq #{id}.zip #{id}/ && cd ../../"
     system(zip)
   end
 
   # generates a tileset at public/tms/<id>/
   def self.generate_jpg(id, root)
-    imageMagick = 'convert -background white -flatten '+root+'/public/warps/'+id+'/'+id+'-geo.tif '+root+'/public/warps/'+id+'/'+id+'.jpg'
+    imageMagick = "convert -background white -flatten #{root}/public/warps/#{id}/#{id}-geo.tif #{root}/public/warps/#{id}/#{id}.jpg"
     system(self.ulimit+imageMagick)
   end
 
@@ -325,7 +325,7 @@ class MapKnitterExporter
       export.jpg = false
       export.save
 
-      directory = "#{root}/public/warps/"+id+"/"
+      directory = "#{root}/public/warps/#{id}/"
       stdin, stdout, stderr = Open3.popen3('rm -r '+directory.to_s)
       puts stdout.readlines
       puts stderr.readlines

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -26,16 +26,16 @@ class MapKnitterExporter
   ## Run on each image:
 
   # pixels per meter = pxperm 
-  def self.generate_perspectival_distort(pxperm, path, nodes_array, id, image_file_name, img_url, height, width, root = "https://mapknitter.org")
+  def self.generate_perspectival_distort(pxperm, id, nodes_array, image_file_name, img_url, height, width, root = "https://mapknitter.org")
     require 'net/http'
     
     # everything in -working/ can be deleted; 
     # this is just so we can use the files locally outside of s3
-    working_directory = get_working_directory(path)
+    working_directory = get_working_directory(id)
     Dir.mkdir(working_directory) unless (File.exists?(working_directory) && File.directory?(working_directory))
     local_location = working_directory+id.to_s+'-'+image_file_name.to_s
 
-    directory = warps_directory(path)
+    directory = warps_directory(id)
     Dir.mkdir(directory) unless (File.exists?(directory) && File.directory?(directory))
     completed_local_location = directory+id.to_s+'.png'
 
@@ -206,7 +206,7 @@ class MapKnitterExporter
     system(self.ulimit+gdalwarp)
 
     # deletions could happen here; do it in distinct method so we can run it independently
-    delete_temp_files(path)
+    delete_temp_files(id)
 
     [x1,y1]
   end

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -239,7 +239,6 @@ class MapKnitterExporter
        scale,
        id,
        image[:nodes_array],
-       image[:id],
        image[:filename],
        image[:url],
        image[:height],

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -82,6 +82,10 @@ class MapKnitterExporter
       }
     else
       require "fileutils"
+      puts '>>>>>>>>>>>>>>oldfashioned'
+      puts 'img_url, local_location'
+      puts img_url
+      puts local_location
       FileUtils.cp(img_url, local_location)
     end
 

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -10,11 +10,11 @@ class MapKnitterExporter
   end
 
   def self.get_working_directory(path)
-    "public/warps/" + path + "-working/"
+    "public/warps/#{path}-working/"
   end
 
   def self.warps_directory(path)
-    "public/warps/" + path + "/"
+    "public/warps/#{path}/"
   end
 
   def self.delete_temp_files(path)

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -71,7 +71,7 @@ class MapKnitterExporter
     # puts x1.to_s+','+y1.to_s+','+x2.to_s+','+y2.to_s
 
     # should determine if it's stored in s3 or locally:
-    if (img_url[0..3] == 'http')
+    if (img_url.slice(0,4) == 'http')
       Net::HTTP.start('s3.amazonaws.com') { |http|
       #Net::HTTP.start('localhost') { |http|
         puts (img_url)

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -51,7 +51,6 @@ class ExporterTest < Minitest::Test
       scale, 
       id,
       nodes_array,
-      image[:filename],
       image[:url],
       image[:height],
       image[:width],

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -77,6 +77,7 @@ class ExporterTest < Minitest::Test
     assert origin
     ordered = false
 
+    system("rm -r public/warps/#{id}/1-geo.tif")
     system("mkdir -p public/warps/#{id}")
     system("mkdir -p public/tms/#{id}")
     # these params could be compressed - warpable coords is part of origin; are coords and origin required?
@@ -106,10 +107,11 @@ class ExporterTest < Minitest::Test
     # test deletion of the files; they were already deleted in run_export, 
     # so let's make new dummy ones:
     # make a sample image
-    system('mkdir -p public/system/images/2/original/')
-    system('touch public/system/images/2/original/test.png')
+    system('mkdir -p public/system/images/1/original/')
+    system('touch public/system/images/1/original/test.png')
     system("mkdir -p public/warps/#{id}")
     system("mkdir -p public/tms/#{id}")
+    system("touch public/tms/#{id}/#{id}.zip")
     system("touch public/warps/#{id}/folder")
     assert File.exist?("public/warps/#{id}/folder")
     system("mkdir -p public/warps/#{id}-working")

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -77,7 +77,6 @@ class ExporterTest < Minitest::Test
     assert origin
     ordered = false
 
-    system("rm -r public/warps/#{id}/1-geo.tif")
     system("mkdir -p public/warps/#{id}")
     system("mkdir -p public/tms/#{id}")
     # these params could be compressed - warpable coords is part of origin; are coords and origin required?

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -92,7 +92,7 @@ class ExporterTest < Minitest::Test
 
     assert MapKnitterExporter.zip_tiles(id)
 
-    assert MapKnitterExporter.generate_jpg(id, root)
+    assert MapKnitterExporter.generate_jpg(id, '.') # '.' as root
 
     assert MapKnitterExporter.run_export(
       user_id,

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -90,15 +90,19 @@ class ExporterTest < Minitest::Test
 
     assert MapKnitterExporter.generate_tiles('', id, root)
 
+    system("mkdir -p public/tms/#{id}")
+    system("touch public/tms/#{id}/#{id}.zip")
     assert MapKnitterExporter.zip_tiles(id)
 
     assert MapKnitterExporter.generate_jpg(id, '.') # '.' as root
 
+    # run_export(user_id, resolution, export, id, root, placed_warpables, key)
     assert MapKnitterExporter.run_export(
       user_id,
       resolution,
       export,
       id,
+      root,
       [image],
       ''
     )

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -65,7 +65,7 @@ class ExporterTest < Minitest::Test
     system("rm -r public/warps/#{id}/1-geo.tif")
     # make a sample image
     system('mkdir -p public/system/images/2/original/')
-    system('cp test/fixtures/demo.png public/system/images/2/original/test.png')
+    system('cp test/fixtures/demo.png public/system/images/1/original/test.png')
 
     origin = MapKnitterExporter.distort_warpables(
       scale,

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -102,7 +102,7 @@ class ExporterTest < Minitest::Test
       resolution,
       export,
       id,
-      '.',
+      root,
       [image],
       ''
     )

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -69,7 +69,7 @@ class ExporterTest < Minitest::Test
 
     origin = MapKnitterExporter.distort_warpables(
       scale,
-      [image], # TODO: here it also expects image to have a nodes_array object
+      [image],
       export,
       id
     )
@@ -83,7 +83,7 @@ class ExporterTest < Minitest::Test
     assert MapKnitterExporter.generate_composite_tiff(
       warpable_coords,
       origin,
-      [{nodes_array: nodes_array}], # TODO: here it wants a collection of objects, each with a nodes_array
+      [image],
       id,
       ordered
     )
@@ -99,7 +99,7 @@ class ExporterTest < Minitest::Test
       resolution,
       export,
       id,
-      [image], # TODO: these images need a nodes_array
+      [image],
       ''
     )
 

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -51,6 +51,7 @@ class ExporterTest < Minitest::Test
       scale, 
       id,
       nodes_array,
+      image[:filename],
       image[:url],
       image[:height],
       image[:width],

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -4,7 +4,6 @@ require "./lib/mapknitterExporter"
 class ExporterTest < Minitest::Test
   def test_all_functions # break this into separate parts
 
-    slug = "ten-forward"
     id = 1
     user_id = 1
     scale = 2
@@ -43,16 +42,15 @@ class ExporterTest < Minitest::Test
     # make a sample image
     system('mkdir -p public/system/images/1/original')
     system('cp test/fixtures/demo.png public/system/images/1/original/')
-    system("mkdir -p public/warps/#{slug}")
-    system("mkdir -p public/tms/#{slug}")
-    system("touch public/warps/#{slug}/folder")
-    assert File.exist?("public/warps/#{slug}/folder")
+    system("mkdir -p public/warps/#{id}")
+    system("mkdir -p public/tms/#{id}")
+    system("touch public/warps/#{id}/folder")
+    assert File.exist?("public/warps/#{id}/folder")
 
     coords = MapKnitterExporter.generate_perspectival_distort(
       scale, 
-      slug,
+      id,
       nodes_array,
-      id, 
       image[:filename],
       image[:url],
       image[:height],
@@ -60,11 +58,11 @@ class ExporterTest < Minitest::Test
       '' # root
     )
     assert coords
-    assert MapKnitterExporter.get_working_directory(slug)
-    assert MapKnitterExporter.warps_directory(slug)
+    assert MapKnitterExporter.get_working_directory(id)
+    assert MapKnitterExporter.warps_directory(id)
 
     # get rid of existing geotiff
-    system("rm -r public/warps/#{slug}/1-geo.tif")
+    system("rm -r public/warps/#{id}/1-geo.tif")
     # make a sample image
     system('mkdir -p public/system/images/2/original/')
     system('cp test/fixtures/demo.png public/system/images/2/original/test.png')
@@ -73,38 +71,35 @@ class ExporterTest < Minitest::Test
       scale,
       [image], # TODO: here it also expects image to have a nodes_array object
       export,
-      slug
+      id
     )
     lowest_x, lowest_y, warpable_coords = origin
     assert origin
     ordered = false
 
-    system("mkdir -p public/warps/#{slug}")
-    system("mkdir -p public/tms/#{slug}")
+    system("mkdir -p public/warps/#{id}")
+    system("mkdir -p public/tms/#{id}")
     # these params could be compressed - warpable coords is part of origin; are coords and origin required?
     assert MapKnitterExporter.generate_composite_tiff(
       warpable_coords,
       origin,
-      [image],
-      slug,
+      [{nodes_array: nodes_array}], # TODO: here it wants a collection of objects, each with a nodes_array
+      id,
       ordered
     )
 
-    assert MapKnitterExporter.generate_tiles('.', slug, root)
+    assert MapKnitterExporter.generate_tiles('', id, root)
 
-    assert MapKnitterExporter.zip_tiles(slug)
+    assert MapKnitterExporter.zip_tiles(id)
 
-    assert MapKnitterExporter.generate_jpg(slug, '.')
+    assert MapKnitterExporter.generate_jpg(id, root)
 
     assert MapKnitterExporter.run_export(
       user_id,
       resolution,
       export,
       id,
-      slug,
-      root,
-      scale,
-      [image],
+      [image], # TODO: these images need a nodes_array
       ''
     )
 
@@ -113,13 +108,13 @@ class ExporterTest < Minitest::Test
     # make a sample image
     system('mkdir -p public/system/images/2/original/')
     system('touch public/system/images/2/original/test.png')
-    system("mkdir -p public/warps/#{slug}")
-    system("mkdir -p public/tms/#{slug}")
-    system("touch public/warps/#{slug}/folder")
-    assert File.exist?("public/warps/#{slug}/folder")
-    system("mkdir -p public/warps/#{slug}-working")
-    system("touch public/warps/#{slug}/test.png")
-    assert MapKnitterExporter.delete_temp_files(slug)
+    system("mkdir -p public/warps/#{id}")
+    system("mkdir -p public/tms/#{id}")
+    system("touch public/warps/#{id}/folder")
+    assert File.exist?("public/warps/#{id}/folder")
+    system("mkdir -p public/warps/#{id}-working")
+    system("touch public/warps/#{id}/test.png")
+    assert MapKnitterExporter.delete_temp_files(id)
   end
 end
 

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -102,7 +102,7 @@ class ExporterTest < Minitest::Test
       resolution,
       export,
       id,
-      root,
+      '.',
       [image],
       ''
     )

--- a/test/exporter_test.rb
+++ b/test/exporter_test.rb
@@ -64,7 +64,7 @@ class ExporterTest < Minitest::Test
     # get rid of existing geotiff
     system("rm -r public/warps/#{id}/1-geo.tif")
     # make a sample image
-    system('mkdir -p public/system/images/2/original/')
+    system('mkdir -p public/system/images/1/original/')
     system('cp test/fixtures/demo.png public/system/images/1/original/test.png')
 
     origin = MapKnitterExporter.distort_warpables(


### PR DESCRIPTION
Merge once we resolve everything and after #4; also refactor https://github.com/publiclab/mapknitter/ to use this, and make downstream adjustments in https://github.com/publiclab/mapknitter-exporter-sinatra/

## Changes:

turned `slug` into `id` (will need test fixes), removed `average_scale`

`def self.run_export(user_id, resolution, export, id, slug, root, average_scale, placed_warpables, key)` became
`def self.run_export(user_id, resolution, export, id, root, placed_warpables, key)`

`def self.generate_perspectival_distort(pxperm, path, nodes_array, id, image_file_name, img_url, height, width, root = "https://mapknitter.org")` became
`def self.generate_perspectival_distort(pxperm, id, nodes_array, image_file_name, img_url, height, width, root = "https://mapknitter.org")`