### PR TITLE
Cartagen require fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
     docker build . -t lib-mapknitter-exporter:latest
 
 script:
-    docker run lib-mapknitter-exporter ruby test/exporter_test.rb
+    docker run lib-mapknitter-exporter bundle exec ruby test/exporter_test.rb

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -1,4 +1,4 @@
-require './lib/cartagen.rb'
+require 'cartagen'
 require 'open3'
 
 class MapKnitterExporter

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -1,4 +1,4 @@
-require 'cartagen'
+require './lib/cartagen.rb'
 require 'open3'
 
 class MapKnitterExporter


### PR DESCRIPTION
This makes `require 'cartagen'` work in testing here and also when required externally.

Here's a build of `mapknitter-exporter-sinatra` that runs tests allright and builds against this branch.
https://travis-ci.com/publiclab/mapknitter-exporter-sinatra/builds/108205469