### PR TITLE
Fix require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
     docker build . -t lib-mapknitter-exporter:latest
 
 script:
-    docker run lib-mapknitter-exporter ruby test/exporter_test.rb
+    docker run lib-mapknitter-exporter bundle exec ruby test/exporter_test.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,12 @@ RUN apt-get update -qq && apt-get install -y \
   gdal-bin curl procps git imagemagick python-gdal zip
 RUN sed -i 's/<policy domain="delegate" rights="none" pattern="HTTPS" \/>//g' /etc/ImageMagick-6/policy.xml
 
-# Install bundle of gems
-WORKDIR /tmp
-ADD Gemfile /tmp/Gemfile
-ADD Gemfile.lock /tmp/Gemfile.lock
-RUN bundle install
-
 # Add the Rails app
 ADD . /app
 WORKDIR /app
-COPY Gemfile /app/Gemfile
-COPY Gemfile.lock /app/Gemfile.lock
+
+# Install bundle of gems
+RUN bundle install
+
 
 CMD ruby test/exporter_test.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
+gemspec
 ruby "2.4.6"
 gem "minitest", "~>5.11.3"

--- a/lib/mapknitter-exporter.rb
+++ b/lib/mapknitter-exporter.rb
@@ -1,0 +1,2 @@
+require './lib/cartagen'
+require './lib/mapknitterExporter'

--- a/lib/mapknitterExporter.rb
+++ b/lib/mapknitterExporter.rb
@@ -1,4 +1,5 @@
-require './lib/cartagen.rb'
+require 'mapknitter-exporter'
+require 'cartagen'
 require 'open3'
 
 class MapKnitterExporter

--- a/mapknitter-exporter.gemspec
+++ b/mapknitter-exporter.gemspec
@@ -6,7 +6,8 @@ Gem::Specification.new do |s|
   s.description = "The GDAL/ImageMagick-based exporter system from MapKnitter"
   s.authors     = ["Jeffrey Warren"]
   s.email       = 'jeff@unterbahn.com'
-  s.files       = ["lib/mapknitterExporter.rb", "lib/cartagen.rb"]
+  s.files       = ["lib/mapknitterExporter.rb"]
+  s.require_paths = ["lib"]
   s.homepage    =
     'http://rubygems.org/gems/mapknitter-exporter'
   s.license       = 'GPLv3'

--- a/mapknitter-exporter.gemspec
+++ b/mapknitter-exporter.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "The GDAL/ImageMagick-based exporter system from MapKnitter"
   s.authors     = ["Jeffrey Warren"]
   s.email       = 'jeff@unterbahn.com'
-  s.files       = ["lib/mapknitterExporter.rb"]
+  s.files       = ["lib/mapknitterExporter.rb", "lib/cartagen.rb", "lib/mapknitter-exporter.rb"]
   s.require_paths = ["lib"]
   s.homepage    =
     'http://rubygems.org/gems/mapknitter-exporter'


### PR DESCRIPTION
This makes it so that requires are from the gemspec - 

We were having the issue that this Gem, once required, would fail to find `cartagen.rb`.
The way that it was referenced as `./lib/cartagen.rb` could not be found once the gem was required.